### PR TITLE
Remove obsolete feature wrappers

### DIFF
--- a/econ499/feats/fpca_feats.py
+++ b/econ499/feats/fpca_feats.py
@@ -1,4 +1,0 @@
-from iv_drl.features.build_iv_fpca import main
- 
-if __name__ == "__main__":
-    main() 

--- a/econ499/feats/macro_feats.py
+++ b/econ499/feats/macro_feats.py
@@ -1,4 +1,0 @@
-from iv_drl.features.fetch_macro import main
-
-if __name__ == "__main__":
-    main() 

--- a/econ499/feats/merge_feats.py
+++ b/econ499/feats/merge_feats.py
@@ -1,4 +1,0 @@
-from econ499.panels.merge_features import main
-
-if __name__ == "__main__":
-    main() 

--- a/econ499/feats/price_feats.py
+++ b/econ499/feats/price_feats.py
@@ -1,4 +1,0 @@
-from iv_drl.features.build_price import main
-
-if __name__ == "__main__":
-    main() 

--- a/econ499/feats/surface_feats.py
+++ b/econ499/feats/surface_feats.py
@@ -1,4 +1,0 @@
-from iv_drl.features.build_iv_surface import main
-
-if __name__ == "__main__":
-    main() 

--- a/scripts/rebuild_all.sh
+++ b/scripts/rebuild_all.sh
@@ -5,19 +5,19 @@
 set -euo pipefail
 
 echo "[1/6]  Building SPX price features"
-python build_spx_price_features.py | cat
+python -m econ499.feats.build_price | cat
 
 echo "[2/6]  Building IV-surface statistics"
-python build_iv_surface_features.py | cat
+python -m econ499.feats.build_iv_surface | cat
 
 echo "[3/6]  Building IV FPCA factors"
-python build_iv_fpca_factors.py | cat
+python -m econ499.feats.build_iv_fpca | cat
 
 echo "[4/6]  Building macro features"
-python fetch_macro_series.py | cat
+python -m econ499.feats.fetch_macro | cat
 
 echo "[5/6]  Merging feature sets"
-python merge_feature_sets.py | cat
+python -m econ499.panels.merge_features | cat
 
 # ------------------- hyper-parameter tuning -------------------
 


### PR DESCRIPTION
## Summary
- remove thin wrapper modules under `econ499/feats`
- call real feature builders in `scripts/rebuild_all.sh`

## Testing
- `ruff .` *(fails: numerous style errors)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0d1d90cc833181ffb8f57e99f549