### PR TITLE
Update pipeline module paths

### DIFF
--- a/econ499/orchestrate/regenerate_artifacts.py
+++ b/econ499/orchestrate/regenerate_artifacts.py
@@ -1,4 +1,4 @@
-from iv_drl.orchestration.run_pipeline import run_pipeline as main
+from econ499.orchestrate.run_pipeline import run_pipeline as main
 
 if __name__ == "__main__":
     import argparse

--- a/econ499/orchestrate/run_pipeline.py
+++ b/econ499/orchestrate/run_pipeline.py
@@ -22,16 +22,31 @@ ARTIFACT_TABLE = Path(__file__).resolve().parents[2] / "artifacts" / "tables" / 
 
 # (module, callable, description, output path)
 _TASKS: list[tuple[str, str, str, Path | None]] = [
-    ("econ499.features.build_price", "main", "SPX price features", DATA_DIR / "spx_daily_features.parquet"),
     (
-        "econ499.features.build_iv_surface",
+        "econ499.feats.build_price",
+        "main",
+        "SPX price features",
+        DATA_DIR / "spx_daily_features.parquet",
+    ),
+    (
+        "econ499.feats.build_iv_surface",
         "main",
         "IV-surface features",
         DATA_DIR / "iv_surface_daily_features.parquet",
     ),
-    ("econ499.features.fetch_macro", "main", "Macro series", DATA_DIR / "macro_daily_features.parquet"),
+    (
+        "econ499.feats.fetch_macro",
+        "main",
+        "Macro series",
+        DATA_DIR / "macro_daily_features.parquet",
+    ),
     ("econ499.panels.merge_features", "merge", "Merge feature sets", DATA_DIR / "spx_iv_drl_state.csv"),
-    ("econ499.evaluation.evaluate_all", "evaluate_all", "Evaluate forecasts", ARTIFACT_TABLE),
+    (
+        "econ499.eval.evaluate_all",
+        "evaluate_all",
+        "Evaluate forecasts",
+        ARTIFACT_TABLE,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- use `econ499.feats.*` modules in the orchestrator `_TASKS`
- import `run_pipeline` from the `econ499.orchestrate` package

## Testing
- `ruff check .` *(fails: Invalid `# noqa` directive, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0d1edd4c833182f9f7269182d0ca