### PR TITLE
Fix imports and cleanup walk forward evaluation

### DIFF
--- a/econ499/eval/eval_walk_forward.py
+++ b/econ499/eval/eval_walk_forward.py
@@ -6,21 +6,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-<<<<<<< HEAD
-from iv_drl.utils import load_config
-from iv_drl.utils.metrics_utils import rmse, mae
-from econ499.eval.utils import _load_predictions, _mape, _qlike
-from econ499.eval.evaluate_all import _find_forecast_col
-=======
 from econ499.utils import load_config
 from econ499.utils.metrics_utils import rmse, mae
-from econ499.eval.evaluate_all import (
-    _load_predictions,
-    _find_forecast_col,
-    _mape,
-    _qlike,
-)
->>>>>>> origin/main
+from econ499.eval.utils import _load_predictions, _mape, _qlike
+from econ499.eval.evaluate_all import _find_forecast_col
 
 CFG = load_config("data_config.yaml")
 ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- remove git conflict markers from `eval_walk_forward.py`
- import utilities from `econ499` package

## Testing
- `python -m py_compile econ499/eval/eval_walk_forward.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1bda2bb48331844c185128f042d7