### PR TITLE
Fix penalty flag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ python -m econ499.forecast.make_drl_forecast --model ppo_best_model/best_model.z
 ### Static-Arbitrage Penalty Sensitivity
 ```bash
 # Train with different penalty weights
-python -m econ499.models.ppo --lambda 0  # No penalty
-python -m econ499.models.ppo --lambda 20  # Strong penalty
+python -m econ499.models.ppo --arb_lambda 0  # No penalty
+python -m econ499.models.ppo --arb_lambda 20  # Strong penalty
 ```
 
 ### Alternative Sample Splits


### PR DESCRIPTION
## Summary
- update the README static-arbitrage section to use `--arb_lambda`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1fa27aac833190a01ca04b199299