### PR TITLE
Fix module paths in documentation examples

### DIFF
--- a/econ499/forecast/make_drl_forecast.py
+++ b/econ499/forecast/make_drl_forecast.py
@@ -2,7 +2,7 @@
 
 Usage (from repo root):
 
-    python -m econ499.predict.make_drl_forecast \
+    python -m econ499.forecast.make_drl_forecast \
            --model data_processed/ppo_best_model.zip \
            --out   data_processed/ppo_oos_predictions.csv
 

--- a/econ499/hpo/hpo_lstm.py
+++ b/econ499/hpo/hpo_lstm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Hyper-parameter optimisation for the LSTM baseline using Optuna.
 
 Run:
-    python -m econ499.tune.hpo_lstm --trials 50
+    python -m econ499.hpo.hpo_lstm --trials 50
 This creates an SQLite study in ``data_processed/`` (same folder as other
 HPO studies) and writes the best params to
 ``data_processed/best_lstm_params.json``.


### PR DESCRIPTION
## Summary
- fix the usage line for DRL forecasting script
- adjust HPO example command for the LSTM baseline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e25628e508331a0d360fd0e8e31ce