### PR TITLE
Fix module references

### DIFF
--- a/econ499/forecast/make_drl_forecast.py
+++ b/econ499/forecast/make_drl_forecast.py
@@ -2,7 +2,7 @@
 
 Usage (from repo root):
 
-    python -m econ499.predict.make_drl_forecast \
+    python -m econ499.forecast.make_drl_forecast \
            --model data_processed/ppo_best_model.zip \
            --out   data_processed/ppo_oos_predictions.csv
 

--- a/scripts/run_ablation.sh
+++ b/scripts/run_ablation.sh
@@ -19,20 +19,20 @@ MODEL_A2C="$MODEL_A2C_DIR/best_model.zip"
 
 for block in "${BLOCKS[@]}"; do
   echo "[ABLATION] Training PPO without block: $block"
-  python -m econ499.agents.ppo --timesteps "$TIMESTEPS" --exclude_block "$block" --arb_lambda 10 | cat
+  python -m econ499.models.ppo --timesteps "$TIMESTEPS" --exclude_block "$block" --arb_lambda 10 | cat
 
   echo "[ABLATION] Saving PPO forecasts"
-  python -m econ499.predict.make_drl_forecast \
+  python -m econ499.forecast.make_drl_forecast \
          --model "$MODEL_PPO" \
          --exclude_block "$block" \
          --out    "$DATA_DIR/ppo_${block}_oos_predictions.csv" \
          | cat
 
   echo "[ABLATION] Training A2C without block: $block"
-  python -m econ499.agents.a2c --timesteps "$TIMESTEPS" --exclude_block "$block" --arb_lambda 10 | cat
+  python -m econ499.models.a2c --timesteps "$TIMESTEPS" --exclude_block "$block" --arb_lambda 10 | cat
 
   echo "[ABLATION] Saving A2C forecasts"
-  python -m econ499.predict.make_drl_forecast \
+  python -m econ499.forecast.make_drl_forecast \
          --model "$MODEL_A2C" \
          --exclude_block "$block" \
          --out    "$DATA_DIR/a2c_${block}_oos_predictions.csv" \


### PR DESCRIPTION
## Summary
- update ablation script to call modules from `econ499.models` and `econ499.forecast`
- update forecast script documentation to new module paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2561a588833196bf1e5c568ac85f