### PR TITLE
Add VVIX config path and use in macro fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ pip install --index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu12
 ### Data Processing Pipeline
 Set the directory containing the OptionMetrics daily ZIP files in
 `cfg/data_config.yaml` under `paths.option_data_zip_dir`.
+You must also set `paths.vvix_csv` to the path of the VVIX history CSV.
 The data processing pipeline consists of the following scripts that must be run in this exact order:
 
 ```powershell

--- a/cfg/data_config.yaml
+++ b/cfg/data_config.yaml
@@ -6,6 +6,7 @@ paths:
   figures_dir: "results/figures"
   tables_dir: "results/tables"
   drl_state_file: "results/spx_iv_drl_state.csv"
+  vvix_csv: "VVIX_History.csv"
 
 settings:
   start_date: "1996-01-01"

--- a/econ499/feats/fetch_macro.py
+++ b/econ499/feats/fetch_macro.py
@@ -27,7 +27,7 @@ YF_EXTRA_TICKERS = {
     "MOVE": "^MOVE",   # BofA MOVE index via Yahoo Finance
 }
 
-VVIX_CSV_PATH = Path("data_processed/VVIX_History.csv").resolve()
+VVIX_CSV_PATH = Path(CONFIG["paths"]["vvix_csv"]).resolve()
 
 
 def fetch_fred_data(api_key=None, start_date="2000-01-01", end_date=datetime.today(), series=None):
@@ -53,8 +53,8 @@ def fetch_fred_data(api_key=None, start_date="2000-01-01", end_date=datetime.tod
 
 
 def fetch_vvix(start_date="2000-01-01", end_date=datetime.today().strftime("%Y-%m-%d")):
-    """Fetch VVIX data from local CSV file.
-    
+    """Fetch VVIX data from the CSV path specified in the config.
+
     The VVIX data is sourced from CBOE's historical data page:
     https://www.cboe.com/tradable_products/vix/vix_historical_data/
     """


### PR DESCRIPTION
## Summary
- configure VVIX CSV location via `cfg/data_config.yaml`
- read VVIX path from config in `fetch_macro.py`
- document new `paths.vvix_csv` setting in the README

## Testing
- `pip install pandas_datareader -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e39071a808331a2ee3d8c42010120