### PR TITLE
Add multi-maturity forecasting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The robustness of our results is assessed through:
 
 ### DRL Environment
 - **State Space**: 70+ engineered features from all feature blocks
-- **Action Space**: Continuous prediction of next-day ATM IV
+- **Action Space**: Vector of length ``n_maturities`` forecasting next-day ATM IV for each maturity
 - **Reward Function**: Negative MSE with static-arbitrage penalty
 - **Constraints**: No-arbitrage conditions enforced through penalty term
 
@@ -125,6 +125,11 @@ python -m econ499.hpo.hpo_a2c --n-trials 30
 python -m econ499.baselines.lstm
 python -m econ499.models.ppo --timesteps 100000
 python -m econ499.models.a2c --timesteps 100000
+
+# Forecast multiple maturities (e.g. 30d and 90d)
+# Set ``features.surface.maturities`` in ``cfg/data_config.yaml`` to ``[30, 90]``
+# and run the same training commands. The agent will output a vector forecast
+# with one prediction per maturity.
 
 # 4. Evaluation
 python -m econ499.eval.evaluate_all

--- a/cfg/data_config.yaml
+++ b/cfg/data_config.yaml
@@ -34,7 +34,7 @@ features:
     window: 252  # 1 year of trading days
     min_periods: 126
   surface:
-    maturities: [30, 60, 90, 180, 365]  # days
+    maturities: [30, 90]  # days (forecast both)
     moneyness_range: [-0.2, 0.2]
   fpca:
     n_components: 3

--- a/econ499/models/a2c.py
+++ b/econ499/models/a2c.py
@@ -32,6 +32,7 @@ def train_a2c(total_timesteps: int = 50_000, action_scale: float = 0.05, *, excl
         train_df,
         valid_df,
         obs_cols=obs_cols,
+        maturities=CONFIG["features"]["surface"]["maturities"],
         action_scale_factor=action_scale,
         reward_type="mse",
         reward_scale=1000,

--- a/econ499/models/ppo.py
+++ b/econ499/models/ppo.py
@@ -33,6 +33,7 @@ def train_ppo(total_timesteps: int = 100_000, action_scale: float = 0.05, *, exc
         train_df,
         valid_df,
         obs_cols=obs_cols,
+        maturities=CONFIG["features"]["surface"]["maturities"],
         action_scale_factor=action_scale,
         reward_type="mse",
         reward_scale=1000,


### PR DESCRIPTION
## Summary
- support vector action space in `IVEnv`
- create envs with configurable maturities
- train PPO/A2C with maturity list from config
- document multi-maturity setup in README
- default maturities set to `[30, 90]`

## Testing
- `flake8` *(fails: many existing style issues)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e39155ea88331bb5c8533d6fc1ecb