### PR TITLE
Add tests for option loading and IV env

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ pip install -r requirements.txt
 pip install --index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu121 torchvision torchaudio
 ```
 
+### Running Tests
+Install dev dependencies and run pytest to execute the test suite. Continuous integration should use the same commands.
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+
 ### Data Processing Pipeline
 Set the directory containing the OptionMetrics daily ZIP files in
 `cfg/data_config.yaml` under `paths.option_data_zip_dir`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -vv
+testpaths = tests

--- a/tests/test_iv_env.py
+++ b/tests/test_iv_env.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from econ499.envs.iv_env import IVEnv
+
+
+def test_ivenv_step_rewards_and_done():
+    df = pd.DataFrame(
+        {
+            "iv_t_orig": [1.0, 2.0, 3.0],
+            "iv_t_plus1": [1.1, 1.9, 3.0],
+            "feat": [0.0, 0.0, 0.0],
+        }
+    )
+    env = IVEnv(df, ["feat"], reward_scale=1.0)
+    obs, info = env.reset()
+
+    obs1, reward1, term1, trunc1, _ = env.step(np.array([0.0]))
+    assert reward1 == pytest.approx(-0.01)
+    assert not term1
+    assert not trunc1
+    assert env.current_step == 1
+    assert obs1 == pytest.approx(np.array([0.0], dtype=np.float32))
+
+    obs2, reward2, term2, trunc2, _ = env.step(np.array([0.0]))
+    assert reward2 == pytest.approx(-0.01)
+    assert term2
+    assert not trunc2
+    assert env.current_step == 2
+    assert np.all(obs2 == 0)
+
+    with pytest.raises(IndexError):
+        env.step(np.array([0.0]))

--- a/tests/test_load_zipped_options.py
+++ b/tests/test_load_zipped_options.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import zipfile
+from pathlib import Path
+
+from econ499.utils.load_zipped_options import process_zip
+
+
+def test_process_zip_extracts_spx_rows(tmp_path):
+    df = pd.DataFrame(
+        {
+            "quote_date": ["2021-01-01"] * 4,
+            "expiration": ["2021-01-02"] * 4,
+            "option_type": ["call", "put", "call", "put"],
+            "delta_1545": [0.1, -0.1, 0.2, -0.2],
+            "implied_volatility_1545": [0.1, 0.2, 0.3, 0.4],
+            "bid_1545": [1, 2, 3, 4],
+            "ask_1545": [1.1, 2.2, 3.3, 4.4],
+            "underlying_symbol": ["SPX", "^SPX", "SPY", "SPXW"],
+        }
+    )
+    csv_bytes = df.to_csv(index=False).encode()
+    zip_path = tmp_path / "sample.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("data.csv", csv_bytes)
+
+    out = process_zip(zip_path)
+    assert len(out) == 2
+    expected_cols = {
+        "quote_date",
+        "expiration",
+        "call_put",
+        "delta_1545",
+        "implied_volatility_1545",
+        "best_bid",
+        "best_offer",
+        "underlying_symbol",
+    }
+    assert set(out.columns) == expected_cols
+    assert set(out["call_put"]) == {"CALL", "PUT"}


### PR DESCRIPTION
## Summary
- test `process_zip` extracts SPX rows from zipped CSVs
- add synthetic dataset test for `IVEnv.step`
- configure pytest for repo
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e398f69a08331b58b0e630b574bef