### PR TITLE
Add multi-seed and residual robustness scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,33 @@ python -m econ499.eval.eval_walk_forward
 python -m econ499.eval.eval_alt_splits
 ```
 
+### Multi-Seed Experiments
+```bash
+python -m econ499.eval.eval_multi_seed --pattern "ppo_seed*_oos_predictions.csv"
+```
+This aggregates metrics across multiple random seeds to check stability.
+
+### Hyperparameter & Architecture Robustness
+```bash
+# Train with a smaller network
+python -m econ499.models.ppo --hparam_file cfg/ppo_small.yaml
+
+# Train with a larger learning rate
+python -m econ499.models.ppo --hparam_file cfg/ppo_lr_high.yaml
+```
+
+### Residual Diagnostics
+```bash
+python -m econ499.eval.residual_diagnostics --lags 5
+```
+Runs a Ljung-Box test on each model's forecast errors.
+
+### Subsample Analysis
+```bash
+python -m econ499.eval.eval_subsamples --years 2010 2015 2020
+```
+Computes forecast metrics over different market regimes.
+
 ## Directory Structure
 ```
 econ499/

--- a/cfg/ppo_lr_high.yaml
+++ b/cfg/ppo_lr_high.yaml
@@ -1,0 +1,1 @@
+learning_rate: 0.003

--- a/cfg/ppo_small.yaml
+++ b/cfg/ppo_small.yaml
@@ -1,0 +1,2 @@
+policy_kwargs:
+  net_arch: [32, 32]

--- a/econ499/eval/__init__.py
+++ b/econ499/eval/__init__.py
@@ -1,4 +1,15 @@
 from .evaluate_all import evaluate_all  # noqa: F401
 from .stat_tests import dm_test, spa_test, mcs_loss_set  # noqa: F401
+from .eval_multi_seed import evaluate_multi_seed  # noqa: F401
+from .eval_subsamples import evaluate_subsamples  # noqa: F401
+from .residual_diagnostics import check_residuals  # noqa: F401
 
-__all__ = ["evaluate_all", "dm_test", "spa_test", "mcs_loss_set"] 
+__all__ = [
+    "evaluate_all",
+    "dm_test",
+    "spa_test",
+    "mcs_loss_set",
+    "evaluate_multi_seed",
+    "evaluate_subsamples",
+    "check_residuals",
+]

--- a/econ499/eval/eval_multi_seed.py
+++ b/econ499/eval/eval_multi_seed.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Evaluate forecast robustness across multiple random seeds."""
+
+from pathlib import Path
+import re
+import pandas as pd
+import numpy as np
+
+from econ499.utils import load_config
+from econ499.utils.metrics_utils import rmse, mae
+from econ499.eval.utils import _mape, _qlike
+from econ499.eval.evaluate_all import _find_forecast_col
+
+CFG = load_config("data_config.yaml")
+ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = Path(CFG["paths"]["output_dir"]).resolve()
+ARTIFACT_DIR = ROOT / "artifacts" / "tables"
+TARGET_COL = CFG["features"]["target_col"]
+
+
+def _build_eval_df(panel_csv: str | Path | None = None) -> pd.DataFrame:
+    if panel_csv is None:
+        default_path = Path(CFG["paths"]["drl_state_file"]).resolve()
+        alt_path = DATA_DIR / "spx_iv_drl_state.csv"
+        panel_csv = default_path if default_path.exists() else alt_path
+    panel = pd.read_csv(panel_csv, parse_dates=["date"]).sort_values("date")
+    panel["IV_next"] = panel[TARGET_COL].shift(-1)
+    panel.dropna(subset=["IV_next"], inplace=True)
+
+    eval_df = panel[["date", "IV_next"]].copy()
+    eval_df["naive"] = panel[TARGET_COL].values
+    eval_df["ar1"] = panel[TARGET_COL].shift(1).rolling(2, min_periods=1).mean().bfill()
+    return eval_df
+
+
+def evaluate_multi_seed(pattern: str = "*_seed*_oos_predictions.csv", *, panel_csv: str | Path | None = None) -> Path:
+    """Aggregate forecast metrics across multiple random seeds.
+
+    Parameters
+    ----------
+    pattern : str, default "*_seed*_oos_predictions.csv"
+        Glob pattern used to locate prediction files in ``DATA_DIR``.
+    panel_csv : str or Path, optional
+        Optional override for the evaluation panel CSV.
+    """
+    base_eval = _build_eval_df(panel_csv)
+
+    files = sorted(DATA_DIR.glob(pattern))
+    if not files:
+        raise FileNotFoundError(f"No prediction files matching {pattern}")
+
+    records: list[dict] = []
+    for csv in files:
+        df_pred = pd.read_csv(csv, parse_dates=["date"])
+        col = _find_forecast_col(df_pred)
+        run_name = Path(csv).stem.replace("_oos_predictions", "")
+        algo = re.sub(r"_seed\d+", "", run_name)
+        merged = base_eval.merge(df_pred[["date", col]].rename(columns={col: run_name}), on="date", how="left")
+        merged.dropna(inplace=True)
+        y = merged["IV_next"].to_numpy()
+        yhat = merged[run_name].to_numpy()
+        naive_mae = mae(y, merged["naive"].to_numpy())
+        records.append({
+            "algo": algo,
+            "run": run_name,
+            "RMSE": rmse(y, yhat),
+            "MAE": mae(y, yhat),
+            "MASE": mae(y, yhat) / naive_mae,
+            "MAPE(%)": _mape(y, yhat),
+            "QLIKE": _qlike(y, yhat),
+        })
+
+    metrics = pd.DataFrame(records)
+    summary = metrics.groupby("algo")[["RMSE", "MAE", "MASE", "MAPE(%)", "QLIKE"]].agg(["mean", "std"])
+
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_metrics = ARTIFACT_DIR / "seed_run_metrics.csv"
+    out_summary = ARTIFACT_DIR / "seed_run_summary.csv"
+    metrics.to_csv(out_metrics, index=False, float_format="%.6f")
+    summary.to_csv(out_summary, float_format="%.6f")
+
+    print("Saved per-run metrics ->", out_metrics)
+    print("Saved summary ->", out_summary)
+    return out_summary
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Evaluate multiple seed runs")
+    p.add_argument("--pattern", type=str, default="*_seed*_oos_predictions.csv", help="Glob for forecast files")
+    p.add_argument("--panel_csv", type=str, default=None)
+    args = p.parse_args()
+    evaluate_multi_seed(pattern=args.pattern, panel_csv=args.panel_csv)

--- a/econ499/eval/eval_subsamples.py
+++ b/econ499/eval/eval_subsamples.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Evaluate forecast accuracy across different date ranges."""
+
+from pathlib import Path
+from datetime import datetime
+import pandas as pd
+
+from econ499.utils import load_config
+from econ499.utils.metrics_utils import rmse, mae
+from econ499.eval.utils import _load_predictions, _mape, _qlike
+
+CFG = load_config("data_config.yaml")
+ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = Path(CFG["paths"]["output_dir"]).resolve()
+ARTIFACT_DIR = ROOT / "artifacts" / "tables"
+TARGET_COL = CFG["features"]["target_col"]
+
+
+def _build_eval_df(panel_csv: str | Path | None = None) -> pd.DataFrame:
+    if panel_csv is None:
+        default_path = Path(CFG["paths"]["drl_state_file"]).resolve()
+        alt_path = DATA_DIR / "spx_iv_drl_state.csv"
+        panel_csv = default_path if default_path.exists() else alt_path
+    panel = pd.read_csv(panel_csv, parse_dates=["date"]).sort_values("date")
+    panel["IV_next"] = panel[TARGET_COL].shift(-1)
+    panel.dropna(subset=["IV_next"], inplace=True)
+
+    eval_df = panel[["date", "IV_next"]].copy()
+    eval_df["naive"] = panel[TARGET_COL].values
+    eval_df["ar1"] = panel[TARGET_COL].shift(1).rolling(2, min_periods=1).mean().bfill()
+
+    for name, df_pred in _load_predictions():
+        eval_df = eval_df.merge(df_pred, on="date", how="left")
+    eval_df.dropna(inplace=True)
+    return eval_df
+
+
+def evaluate_subsamples(panel_csv: str | Path | None = None, *, years: list[int] | None = None) -> Path:
+    """Compute metrics on multiple date sub-samples.
+
+    Parameters
+    ----------
+    years : list[int], optional
+        Start years for each sub-sample. Defaults to ``[2010, 2015, 2020]``.
+    """
+    df = _build_eval_df(panel_csv)
+    if years is None:
+        years = [2010, 2015, 2020]
+
+    bounds = years + [df["date"].dt.year.max() + 1]
+    records: list[dict] = []
+
+    for start, end in zip(bounds[:-1], bounds[1:]):
+        mask = (df["date"].dt.year >= start) & (df["date"].dt.year < end)
+        subset = df.loc[mask]
+        if subset.empty:
+            continue
+        y = subset["IV_next"].to_numpy()
+        naive_mae = mae(y, subset["naive"].to_numpy())
+        label = f"{start}-{end-1}"
+        for col in subset.columns:
+            if col in {"date", "IV_next"}:
+                continue
+            yhat = subset[col].to_numpy()
+            records.append({
+                "period": label,
+                "model": col,
+                "RMSE": rmse(y, yhat),
+                "MAE": mae(y, yhat),
+                "MASE": mae(y, yhat) / naive_mae,
+                "MAPE(%)": _mape(y, yhat),
+                "QLIKE": _qlike(y, yhat),
+            })
+
+    out_df = pd.DataFrame(records)
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = ARTIFACT_DIR / "forecast_metrics_subsamples.csv"
+    out_df.to_csv(out_path, index=False, float_format="%.6f")
+    print("Saved sub-sample metrics ->", out_path)
+    return out_path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Evaluate forecasts over sub-samples")
+    p.add_argument("--panel_csv", type=str, default=None)
+    p.add_argument("--years", nargs="*", type=int, help="Start years e.g. 2010 2015 2020")
+    args = p.parse_args()
+    evaluate_subsamples(panel_csv=args.panel_csv, years=args.years)

--- a/econ499/eval/residual_diagnostics.py
+++ b/econ499/eval/residual_diagnostics.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Residual diagnostics for DRL forecasts using Ljung-Box tests."""
+
+from pathlib import Path
+import pandas as pd
+from statsmodels.stats.diagnostic import acorr_ljungbox
+
+from econ499.utils import load_config
+from econ499.utils.metrics_utils import rmse, mae
+from econ499.eval.utils import _load_predictions, _mape, _qlike
+
+CFG = load_config("data_config.yaml")
+ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = Path(CFG["paths"]["output_dir"]).resolve()
+ARTIFACT_DIR = ROOT / "artifacts" / "tables"
+TARGET_COL = CFG["features"]["target_col"]
+
+
+def _build_eval_df(panel_csv: str | Path | None = None) -> pd.DataFrame:
+    if panel_csv is None:
+        default_path = Path(CFG["paths"]["drl_state_file"]).resolve()
+        alt_path = DATA_DIR / "spx_iv_drl_state.csv"
+        panel_csv = default_path if default_path.exists() else alt_path
+    panel = pd.read_csv(panel_csv, parse_dates=["date"]).sort_values("date")
+    panel["IV_next"] = panel[TARGET_COL].shift(-1)
+    panel.dropna(subset=["IV_next"], inplace=True)
+
+    eval_df = panel[["date", "IV_next"]].copy()
+    eval_df["naive"] = panel[TARGET_COL].values
+    eval_df["ar1"] = panel[TARGET_COL].shift(1).rolling(2, min_periods=1).mean().bfill()
+
+    for name, df_pred in _load_predictions():
+        eval_df = eval_df.merge(df_pred, on="date", how="left")
+    eval_df.dropna(inplace=True)
+    return eval_df
+
+
+def check_residuals(panel_csv: str | Path | None = None, *, lags: int = 5) -> Path:
+    df = _build_eval_df(panel_csv)
+    y = df["IV_next"].to_numpy()
+
+    rows = []
+    for col in df.columns:
+        if col in {"date", "IV_next"}:
+            continue
+        resid = df[col].to_numpy() - y
+        lb = acorr_ljungbox(resid, lags=[lags], return_df=True)
+        rows.append({
+            "model": col,
+            "RMSE": rmse(y, df[col].to_numpy()),
+            "LjungBoxQ": lb["lb_stat"].iloc[0],
+            "p_value": lb["lb_pvalue"].iloc[0],
+        })
+
+    out_df = pd.DataFrame(rows).sort_values("RMSE")
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = ARTIFACT_DIR / "forecast_residual_lb.csv"
+    out_df.to_csv(out_path, index=False, float_format="%.6f")
+    print("Saved residual diagnostics ->", out_path)
+    return out_path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Ljung-Box diagnostics for forecast residuals")
+    p.add_argument("--panel_csv", type=str, default=None)
+    p.add_argument("--lags", type=int, default=5)
+    args = p.parse_args()
+    check_residuals(panel_csv=args.panel_csv, lags=args.lags)


### PR DESCRIPTION
## Summary
- add evaluation helpers for multiple random seeds and subsample diagnostics
- add residual Ljung-Box diagnostics
- expose helpers in `econ499.eval`
- update README with new robustness examples
- provide example hyperparameter YAML configs

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e96a0640c8331af81c2870323f062